### PR TITLE
Feature/python virtualenv support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ cover-html: cover-profile
 # Lint
 
 lint:
-	gometalinter --tests ./...
+	gometalinter --tests ./... --disable=gas
 
 # Dependencies
 

--- a/defaults.go
+++ b/defaults.go
@@ -5,5 +5,5 @@ package psh
 const (
 	// DefaultSegments are tbe list of segments to show on the prompt by
 	// default.
-	DefaultSegments = "username,hostname,cwd,git,root"
+	DefaultSegments = "username,hostname,virtualenv,cwd,git,root"
 )

--- a/prompt.go
+++ b/prompt.go
@@ -73,6 +73,8 @@ func (p *Prompt) getSegment(key string) Segment {
 		segment = NewSegmentCWD()
 	case "git":
 		segment = NewSegmentGit()
+	case "virtualenv":
+		segment = NewSegmentVirtualEnv()
 	default:
 		segment = NewSegmentUnknown()
 	}

--- a/segment-virtualenv.go
+++ b/segment-virtualenv.go
@@ -43,6 +43,7 @@ func (s *SegmentVirtualEnv) Render() []byte {
 	if len(s.Data) > 0 {
 		b.Write(SetBackground(SegmentVirtualEnvBackground))
 		fmt.Fprint(&b, " ")
+		fmt.Fprint(&b, " ")
 		b.Write(s.Data)
 		fmt.Fprint(&b, " ")
 	}

--- a/segment-virtualenv.go
+++ b/segment-virtualenv.go
@@ -1,0 +1,50 @@
+// Copyright 2016-2017 The psh Authors. All rights reserved.
+
+package psh
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path"
+)
+
+const (
+	// SegmentVirtualEnvBackground is the background color to use
+	SegmentVirtualEnvBackground = 22 // #585858
+)
+
+// SegmentVirtualEnv implements the python virtual env partial of the prompt.
+//
+// Renders the current virtalenv python environment name if it is available.
+type SegmentVirtualEnv struct {
+	Data []byte
+}
+
+// NewSegmentVirtualEnv creates an instace of SegmentVirtualEnv type.
+func NewSegmentVirtualEnv() *SegmentVirtualEnv {
+	segment := &SegmentVirtualEnv{}
+	return segment
+}
+
+// Compile collects the data for this segment.
+func (s *SegmentVirtualEnv) Compile() {
+	s.Data = []byte("")
+	virtualEnvPath, ok := os.LookupEnv("VIRTUAL_ENV")
+	if ok {
+		virtualEnvName := path.Base(virtualEnvPath)
+		s.Data = []byte(virtualEnvName)
+	}
+}
+
+// Render renders the segment results.
+func (s *SegmentVirtualEnv) Render() []byte {
+	var b bytes.Buffer
+	if len(s.Data) > 0 {
+		b.Write(SetBackground(SegmentVirtualEnvBackground))
+		fmt.Fprint(&b, " ")
+		b.Write(s.Data)
+		fmt.Fprint(&b, " ")
+	}
+	return b.Bytes()
+}

--- a/segment-virtualenv_test.go
+++ b/segment-virtualenv_test.go
@@ -1,0 +1,28 @@
+// Copyright 2016-2017 The psh Authors. All rights reserved.
+package psh
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSegmentVirtualEnvCompile(t *testing.T) {
+	os.Setenv("VIRTUAL_ENV", "/home/user/venv")
+	expected := `venv`
+	segment := NewSegmentVirtualEnv()
+	segment.Compile()
+	if string(segment.Data) != expected {
+		t.Fatalf("Compiled data expected to be %q but got %q", expected, string(segment.Data))
+	}
+}
+
+func TestSegmentVirtualEnvRender(t *testing.T) {
+	os.Setenv("VIRTUAL_ENV", "/home/user/venv")
+	expected := `\[\e[48;5;22m\]  venv `
+	segment := NewSegmentVirtualEnv()
+	segment.Compile()
+	out := segment.Render()
+	if string(out) != expected {
+		t.Fatalf("Rendered segment expected to be %q but got %q", expected, string(out))
+	}
+}

--- a/segment-virtualenv_test.go
+++ b/segment-virtualenv_test.go
@@ -7,7 +7,10 @@ import (
 )
 
 func TestSegmentVirtualEnvCompile(t *testing.T) {
-	os.Setenv("VIRTUAL_ENV", "/home/user/venv")
+	err := os.Setenv("VIRTUAL_ENV", "/home/user/venv")
+	if err != nil {
+		t.Fatalf("Can't set the required enviornment.")
+	}
 	expected := `venv`
 	segment := NewSegmentVirtualEnv()
 	segment.Compile()
@@ -17,7 +20,10 @@ func TestSegmentVirtualEnvCompile(t *testing.T) {
 }
 
 func TestSegmentVirtualEnvRender(t *testing.T) {
-	os.Setenv("VIRTUAL_ENV", "/home/user/venv")
+	err := os.Setenv("VIRTUAL_ENV", "/home/user/venv")
+	if err != nil {
+		t.Fatalf("Can't set the required enviornment.")
+	}
 	expected := `\[\e[48;5;22m\]  venv `
 	segment := NewSegmentVirtualEnv()
 	segment.Compile()


### PR DESCRIPTION
Add support for virtualenv as a segment on the prompt:

* Create a new segment for virtualenv
* Test virtualenv segment
* Add python icon to the segment if available
* Add virtualenv segment to the defaults (full prompt)